### PR TITLE
fold in some changes from iar-backend

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,10 @@
 #
 import os
 import sys
+import django
+
 sys.path.insert(0, os.path.abspath('..'))
+django.setup()
 
 
 # -- General configuration ------------------------------------------------
@@ -169,6 +172,6 @@ rst_prolog = """
 .. |project| replace:: {0}
 .. |author| replace:: {1}
 """.format(
-project,
-author
+    project,
+    author
 )

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ deps=
     flake8=={env:TOXINI_FLAKE8_VERSION:3.5.0}
 commands=
     flake8 --version
-    flake8 project_name doc
+    flake8 .
 
 # Collect static files
 [testenv:collectstatic]


### PR DESCRIPTION
Using the boilerplate in anger resulted in a few fixes we want to back port
from the iar-backend repo. Most importantly, once Django models were added,
building the documentation failed as autodoc cannot import models from
applications unless Django has been set up via django.setup(). Take the
opportunity while there to fix an indent issue in rst_prolog.

The original flake8 config was fine for single-project django repos but it
ignored any additional applications. Change the invocation to scan the entire
repository. Files/directories can be omitted explicitly by modifying the
.flake8 file.