### PR TITLE
settings.base: fix BASE_DIR value

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_module }}/settings/base.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_module }}/settings/base.py
@@ -2,7 +2,7 @@ import os
 
 #: Base directory containing the project. Build paths inside the project via
 #: ``os.path.join(BASE_DIR, ...)``.
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 #: The Django secret key is by default set from the environment. If omitted, a system check will


### PR DESCRIPTION
The ``BASE_DIR`` value was left at that generated by the default Django project template but that assumed that the settings file was located within the project root. In our template we locate settings files within their own ``settings`` module. This means that ``BASE_DIR`` points to ``PROJECT_ROOT`` and not the directory which contains ``PROJECT_ROOT`` as it should.

Add one more ``os.path.dirname()`` wrapper to the calculation of ``BASE_DIR`` to fix this.

This issue was first found in uisautomation/sms-webapp.