### PR TITLE
Suppress circleci build when you push to gh-pages

### DIFF
--- a/{{ cookiecutter.project_slug }}/.circleci/config.yml
+++ b/{{ cookiecutter.project_slug }}/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           command: |
             git config --global user.email "$GH_EMAIL"
             git config --global user.name "$GH_NAME"
-            ghp-import --no-jekyll --push --force build/doc/
+            ghp-import --no-jekyll --push --force --message "Deploy to GitHub pages [ci skip]" build/doc/
 
 workflows:
   version: 2


### PR DESCRIPTION
.. otherwise you will get unnecessary failing builds