### PR TITLE
Dockerfile: move to using our pre-built image

### DIFF
--- a/{{ cookiecutter.project_slug }}/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/Dockerfile
@@ -1,4 +1,4 @@
-FROM uisautomation/django:2.1-py3.7
+FROM uisautomation/django:py3.7-alpine
 
 # Ensure packages are up to date and install some useful utilities
 RUN apk update && apk add git vim postgresql-dev libffi-dev gcc musl-dev \

--- a/{{ cookiecutter.project_slug }}/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM uisautomation/django:2.1-py3.7
 
 # Ensure packages are up to date and install some useful utilities
 RUN apk update && apk add git vim postgresql-dev libffi-dev gcc musl-dev \


### PR DESCRIPTION
Rather than starting from a naked Python image, use our upstream Django 2.1 and Python 3.7 image to speed build times.